### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,5 @@ See also
 
 >Chewy is the best second pilot ever!
 
-[![Downloads](https://img.shields.io/pypi/dm/chewy.svg
-[![Downloads](https://img.shields.io/pypi/v/chewy.svg
+[![Version](https://img.shields.io/pypi/v/chewy.svg)](https://pypi.python.org/pypi/chewy)
 [![Build Status](https://api.travis-ci.org/mutanabbi/chewy.png?branch=master)](https://travis-ci.org/mutanabbi/chewy)

--- a/README.md
+++ b/README.md
@@ -187,6 +187,6 @@ See also
 
 >Chewy is the best second pilot ever!
 
-[![Downloads](https://pypip.in/d/chewy/badge.png)](https://pypi.python.org/pypi/chewy)
-[![Downloads](https://pypip.in/v/chewy/badge.png)](https://pypi.python.org/pypi/chewy)
+[![Downloads](https://img.shields.io/pypi/dm/chewy.svg
+[![Downloads](https://img.shields.io/pypi/v/chewy.svg
 [![Build Status](https://api.travis-ci.org/mutanabbi/chewy.png?branch=master)](https://travis-ci.org/mutanabbi/chewy)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20chewy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `chewy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.